### PR TITLE
single translations from Dato

### DIFF
--- a/config/eleventy/filters.js
+++ b/config/eleventy/filters.js
@@ -62,5 +62,16 @@ module.exports = {
 
   createStringParameters: function (url, params) {
     return url + '?' + Object.keys(params).map(key => key + '=' + params[key]).join('&');
-  }
+  },
+
+  i18n: function(key) {
+    const { locale, translations } = this.ctx;
+    const translation = translations?.[locale]?.[key];
+    if(!translation) {
+      console.warn('Can\'t find translation for: ', key, locale);
+      console.warn('When using i18n in a macro, please import it "with context"');
+      return '';
+    }
+    return translation;
+  },
 };

--- a/src/components/modular-content/index.njk
+++ b/src/components/modular-content/index.njk
@@ -8,7 +8,7 @@
 {% from "modular-content/external-tools/external-tools.njk" import externalTools %}
 {% from "modular-content/card-grid/card-grid.njk" import cardGrid %}
 {% from "modular-content/title/title.njk" import title %}
-{% from "modular-content/responsive-video/responsive-video.njk" import responsiveVideo %}
+{% from "modular-content/responsive-video/responsive-video.njk" import responsiveVideo with context %}
 
 {% set componentByType = {
   rich_text: richText,

--- a/src/components/modular-content/responsive-video/responsive-video.njk
+++ b/src/components/modular-content/responsive-video/responsive-video.njk
@@ -92,7 +92,7 @@
 
 {% macro caption(title, url) %}
   <figcaption class="responsive-video__caption body-small font-muted">
-    Source:
+    {{ 'source' | i18n }}:
     <a href="{{ url }}" class="font-muted" target="_blank" rel="noopener">
       {{ title }}
     </a>

--- a/src/components/site-footer/site-footer.njk
+++ b/src/components/site-footer/site-footer.njk
@@ -23,7 +23,7 @@
       <ol class="footer__legal-items">
         <li class="footer__legal-item">
           <a href="/{{ locale }}/accessibility" class="footer__legal-link body-small">
-            Accessibility
+            {{ 'accessibility' | i18n }}
           </a>
         </li>
         <li class="footer__legal-item">

--- a/src/data/translations.js
+++ b/src/data/translations.js
@@ -1,0 +1,26 @@
+const queryDatoGraphQL = require('../../config/eleventy/query-dato-graphql');
+
+const query = `
+  query Translations($locale: SiteLocale) {
+    allTranslations(locale: $locale) {
+      key
+      value
+    }
+  }
+`;
+
+module.exports = async () => {
+  const { allTranslations } = await queryDatoGraphQL({ query });
+  return allTranslations
+    .reduce((returnObj, { locale, key, value }) => {
+      let newLocaleObj;
+      if(returnObj[locale]) {
+        newLocaleObj = { ...returnObj[locale], ...{ [key]: value } };
+      }
+      else {
+        newLocaleObj = { [key]: value };
+      }
+      return { ...returnObj, [locale]: newLocaleObj };
+    }, {})
+  ;
+};

--- a/src/pages/home.njk
+++ b/src/pages/home.njk
@@ -10,7 +10,7 @@ eleventyComputed:
 ---
 
 {% from "../components/hero/hero.njk" import hero %}
-{% from "modular-content/index.njk" import modularContent %}
+{% from "modular-content/index.njk" import modularContent with context %}
 
 {{ hero(title=item.title, body=item.intro) }}
 {{ modularContent(item.sections) }}


### PR DESCRIPTION
- `i18n` filter that transforms a key to a locale value `{{ 'accessibility' | i18n }}`
- caveat: context needs to be available for the filter to work, so macros need to be imported `with context`