### PR TITLE
refactor DesktopNavigation

### DIFF
--- a/src/components/desktop-navigation/desktop-navigation.njk
+++ b/src/components/desktop-navigation/desktop-navigation.njk
@@ -1,11 +1,12 @@
 {% macro desktopNavigation(items=false, strippedUrl=false, locale=false) %}
+  {%- set baseId = 'desktop-navigation-submenu-' -%}
 
   <nav class="desktop-navigation">
     <ol class="desktop-navigation__items">
       {% for item in items %}
         {%- set isCurrent = (locale + '/' + item.page.slug == strippedUrl) -%}
         {%- set hasSubMenu = item.subMenuItems | length > 0 -%}
-        {%- set id = 'desktop-navigation-submenu-' + loop.index0 -%}
+        {%- set id = baseId + loop.index0 -%}
         <li class="desktop-navigation__item{% if isCurrent %} desktop-navigation__item--active{% endif %}{% if hasSubMenu %} desktop-navigation__item--is-submenu{% endif %}">
 
           <a class="desktop-navigation__item-link" href="/{{ locale }}/{{ item.page.slug }}">
@@ -26,14 +27,18 @@
             <a
               class="desktop-navigation__toggle desktop-navigation__toggle--close"
               href="#"
-              data-toggle data-toggle-id="{{ id }}"
+              data-toggle
+              data-toggle-id="{{ id }}"
+              data-toggle-reset-id="{{ baseId }}"
             >
               <span class="sr-only">Close</span>
             </a>
             <a
               class="desktop-navigation__toggle desktop-navigation__toggle--open"
               href="#{{ id }}"
-              data-toggle data-toggle-id="{{ id }}"
+              data-toggle
+              data-toggle-id="{{ id }}"
+              data-toggle-reset-id="{{ baseId }}"
             >
               <span class="sr-only">Open</span>
             </a>

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -1,4 +1,5 @@
 const toggles = document.querySelectorAll('[data-toggle]')
+const ACTIVE_CLASS = 'toggle--active'
 
 function initToggle() {
   if(!toggles.length) {
@@ -9,13 +10,29 @@ function initToggle() {
     const targetId = toggle.getAttribute('data-toggle-id')
     const target = document.getElementById(targetId)
 
-    toggle.addEventListener('click', event => handleClick(event, target))
+    // toggle 'ACTIVE_CLASS' for targets of same id group
+    const resetId = toggle.getAttribute('data-toggle-reset-id')
+    let resetTargets = []
+
+    if(resetId) {
+      resetTargets = Array.from(document.querySelectorAll(`[id^="${resetId}"]`))
+    }
+
+    toggle.addEventListener('click', event => handleClick(event, target, resetTargets))
   })
 
-  function handleClick(event, target) {
+  function handleClick(event, target, resetTargets) {
     event.preventDefault()
     history.replaceState('', document.title, window.location.pathname + window.location.search) // reset hash if for some reason it ended up in the url
-    target.classList.toggle('toggle--active')
+
+    if(resetTargets.length) {
+      resetTargets.forEach(resetTarget => {
+        if(resetTarget !== target) {
+          resetTarget.classList.remove(ACTIVE_CLASS)
+        }
+      })
+    }
+    target.classList.toggle(ACTIVE_CLASS)
   }
 }
 


### PR DESCRIPTION
refactor DesktopNavigation / extend toggle component: 
- extends toggle functionality with option to remove active toggle class from nodes with the same base-id
- only one menu dropdown open (no overlapping)

Toggle functionality is not moved to desktop-navigation, because the extended option is quite useful for other scenarios as well.