### PR TITLE
Adds SVG support to ResponsiveImage component

### DIFF
--- a/src/components/modular-content/responsive-image/responsive-image.njk
+++ b/src/components/modular-content/responsive-image/responsive-image.njk
@@ -8,21 +8,32 @@
         class="responsive-image__fixed-ratio"
         style="--image-width: {{ blockData.imageWidth or 100}}%"
       >
-        <span
-          class="responsive-image__spacer"
-          style="padding-top: {{ 100.0 / image.responsiveImage.aspectRatio }}%;
-              background-image: url({{ image.responsiveImage.base64 }});"
-        ></span>
-        <picture class="responsive-image__picture">
-          <source type="image/webp" srcset="{{ image.url | imageUrl({ w: 776, fm: 'webp' }) }}">
+        {% if image.format === 'svg' %}
           <img
-            alt="{{ image.alt }}"
-            src="{{ image.url | imageUrl({ w: 776 }) }}"
-            loading="lazy"
-            class="responsive-image__figure-image"
-            style="width:100%; height:100%;"
-          />
-        </picture>
+              alt="{{ image.alt }}"
+              src="{{ image.url }}"
+              loading="lazy"
+              width="{{ image.width }}"
+              height="{{ image.height }}"
+              class="responsive-image__figure-image"
+            />
+        {% else %}
+          <span
+            class="responsive-image__spacer"
+            style="padding-top: {{ 100.0 / image.responsiveImage.aspectRatio }}%;
+                background-image: url({{ image.responsiveImage.base64 }});"
+          ></span>
+          <picture class="responsive-image__picture">
+            <source type="image/webp" srcset="{{ image.url | imageUrl({ w: 1200, fm: 'webp' }) }}">
+            <img
+              alt="{{ image.alt }}"
+              src="{{ image.url | imageUrl({ w: 1200 }) }}"
+              loading="lazy"
+              class="responsive-image__figure-image"
+              style="width:100%; height:100%;"
+            />
+          </picture>
+        {% endif %}
       </div>
       {% if caption %}
         <figcaption class="responsive-image__caption rich-text body-small font-muted">

--- a/src/components/modular-content/responsive-image/responsive-image.scss
+++ b/src/components/modular-content/responsive-image/responsive-image.scss
@@ -8,6 +8,7 @@
 
 .responsive-image__spacer {
   display: block;
+  background-size: cover;
 }
 
 .responsive-image__picture {

--- a/src/pages/_slug.11tydata.graphql
+++ b/src/pages/_slug.11tydata.graphql
@@ -96,6 +96,9 @@ query PageSlug($locale: SiteLocale) {
           title
           url
           alt
+          format
+          width
+          height
           responsiveImage {
             base64
             bgColor

--- a/src/pages/home.11tydata.graphql
+++ b/src/pages/home.11tydata.graphql
@@ -59,6 +59,9 @@ query Home($locale: SiteLocale) {
         image {
           url
           alt
+          format
+          width
+          height
           responsiveImage {
             aspectRatio
             base64


### PR DESCRIPTION
- extends `responsive-image` component to handle svg format
- sets default `width` in query params to `1200` to prevent pixelated images
- sets the `background-size` for the `responsive-image__spacer` (was default `background-repeat: repeat`)